### PR TITLE
Feature/3 rootview navigation

### DIFF
--- a/MentBox/MentBox/Managers/NavigationManager.swift
+++ b/MentBox/MentBox/Managers/NavigationManager.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+enum AppRootView: Equatable {
+    case auth(AuthView)
+    case mentor(MentorView)
+    case learner(LearnerView)
+}
+
 // Auth뷰
 enum AuthView: Hashable {
     case login
@@ -9,7 +15,6 @@ enum AuthView: Hashable {
 
 // Mentor뷰
 enum MentorView: Hashable {
-    case profile
     case home
     case myPage
 }
@@ -18,24 +23,23 @@ enum MentorView: Hashable {
 enum LearnerView: Hashable {
     case home
     case chatRoom(mentorId: String)
-    case profile
     case myPage
-    case bookMark
+    case myLetter
 }
 
 class NavigationManager: ObservableObject {
     @Published var path = NavigationPath()
-    @Published var rootView: AuthView = .login
-    @Published var mentorView: MentorView?
-    @Published var learnerView: LearnerView?
-    
+    @Published var rootView: AppRootView = .auth(.login)
+
+    // 같은이름 navigate는 추후 수정이 필요할 듯 책임 명확히
     func navigate(to destination: MentorView) {
         path.append(destination)
     }
-    
+
     func navigate(to destination: LearnerView) {
         path.append(destination)
     }
+
     func navigate(to destination: AuthView) {
         path.append(destination)
     }
@@ -47,23 +51,19 @@ class NavigationManager: ObservableObject {
     func pop() {
         path.removeLast()
     }
-    
-    func setMainRoot(userType: UserType) {  //로그인할 떄 넣어줘야하는 페이지 
+
+    func setMainRoot(userType: UserType) {
         path = NavigationPath()
-        rootView = .userTypeSelection
-        if userType == .mentor { // 멘토뷰 
-            mentorView = .profile
-            learnerView = nil
-        } else {  //러너 뷰 
-            mentorView = nil
-            learnerView = .profile
+        switch userType {
+        case .mentor:
+            rootView = .mentor(.home)
+        case .learner:
+            rootView = .learner(.home)
         }
     }
-    
-    func setAuthRoot() {  // 로그아웃 했을 때 씀 
+
+    func setAuthRoot() {
         path = NavigationPath()
-        rootView = .login
-        mentorView = nil
-        learnerView = nil
+        rootView = .auth(.login)
     }
 }

--- a/MentBox/MentBox/MentBoxApp.swift
+++ b/MentBox/MentBox/MentBoxApp.swift
@@ -28,22 +28,38 @@ struct MentBoxApp: App {
     // Group 'v'에러 -> ViewBuilder로 조건부 뷰 보여주기
     @ViewBuilder
     private var rootContent: some View {
-        if let mentorView = navigationManager.mentorView {
-            MentorMainView()
-        } else if let learnerView = navigationManager.learnerView {
-            LearnerMainView()
-        } else {
-            switch navigationManager.rootView {
+        switch navigationManager.rootView {
+        case .auth(let authView):
+            switch authView {
             case .login:
                 SignInView()
             case .userTypeSelection:
-                UserTypeSelectionView(
-                    selectedUserType: .constant(nil)
-                )
+                UserTypeSelectionView(selectedUserType: .constant(nil))
             case .userInfoInput(let userType):
                 UserInfoInputView(userType: userType) {
                     navigationManager.setMainRoot(userType: userType)
                 }
+            }
+
+        case .mentor(let mentorView):
+            switch mentorView {
+            case .home:
+                MentorMainView()
+            case .myPage:
+                MentorProfileView()
+            }
+
+        case .learner(let learnerView):
+            switch learnerView {
+            case .home:
+                LearnerMainView()
+            case .chatRoom(let mentorId):
+//                ChatRoomView(mentorId: mentorId)
+                Text("Hi chatview")
+            case .myLetter:
+                MyLetterView()
+            case .myPage:
+                LearnerProfileView()
             }
         }
     }
@@ -51,8 +67,8 @@ struct MentBoxApp: App {
     var body: some Scene {
         WindowGroup {
             rootContent // 조건 분기는 모두 여기서 해결
-                .ignoresSafeArea()
                 .environmentObject(navigationManager)
+                .ignoresSafeArea()
         }
     }
 }

--- a/MentBox/MentBox/Views/Auth/SignInView.swift
+++ b/MentBox/MentBox/Views/Auth/SignInView.swift
@@ -53,7 +53,7 @@ struct SignInView: View {
                 
                 if isLoading {
                     ProgressView()
-                        .padding()
+//                        .padding()
                 }
                 
                 SignInWithAppleButton(
@@ -88,29 +88,19 @@ struct SignInView: View {
                     .frame(height: 40)
             }
         }
-        // NavigationLink(value: AuthView.userTypeSelection) {
-        //     UserTypeSelectionView(selectedUserType: $selectedUserType) { userType in
-        //         handleUserTypeSelection(userType: userType)
-        //     }
-        // }
-        // .sheet(isPresented: $showUserTypeSelection) {
-        //     UserTypeSelectionView(selectedUserType: $selectedUserType) { userType in
-        //         handleUserTypeSelection(userType: userType)
-        //     }
-        // }
         .onAppear {
             if !isLoggedOut {
                 checkUserType()
             }
         }
-        .fullScreenCover(item: $currentUserType) { userType in
-            switch userType {
-            case .learner:
-                LearnerMainView()
-            case .mentor:
-                MentorMainView()
-            }
-        }
+//        .fullScreenCover(item: $currentUserType) { userType in
+//            switch userType {
+//            case .learner:
+//                LearnerMainView()
+//            case .mentor:
+//                MentorMainView()
+//            }
+//        }
     }
     
     private func handleUserTypeSelection(userType: UserType) {
@@ -121,6 +111,7 @@ struct SignInView: View {
         }
     }
     
+    // 이미 가입이 되어 있을 때
     private func checkUserType() {
         guard let userId = Auth.auth().currentUser?.uid else { return }
         
@@ -132,6 +123,7 @@ struct SignInView: View {
                 if let _ = try await FirebaseService.shared.fetchLearner(userId: userId) {
                     await MainActor.run {
                         currentUserType = .learner
+                        navigationManager.setMainRoot(userType: .learner)
                         isLoading = false
                     }
                     return
@@ -142,6 +134,9 @@ struct SignInView: View {
                 if mentorDoc.exists {
                     await MainActor.run {
                         currentUserType = .mentor
+                        print("멘토 로그인 성공 - 화면 전환 시도")
+                        navigationManager.setMainRoot(userType: .mentor)
+                        print("멘토 화면 전환 완료: \(navigationManager.rootView)")
                         isLoading = false
                     }
                 } else {
@@ -196,7 +191,7 @@ struct SignInView: View {
                             } else {
                                 await MainActor.run {
                                     isLoading = false
-                                    navigationManager.rootView = .userTypeSelection
+                                    navigationManager.rootView = .auth(.userTypeSelection)
                                     showUserTypeSelection = true
                                 }
                             }

--- a/MentBox/MentBox/Views/Learner/LearnerMainView.swift
+++ b/MentBox/MentBox/Views/Learner/LearnerMainView.swift
@@ -4,6 +4,7 @@ struct LearnerMainView: View {
     @State private var selectedTab = 0
     @State private var mentors: [Mentor] = []
     @State private var isLoading = true
+    @EnvironmentObject private var navigationManager: NavigationManager
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -27,7 +28,7 @@ struct LearnerMainView: View {
                         .tag(2)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
-                .padding(.bottom, 70)   // leave space for the custom tab bar
+                .padding(.bottom, 70)
 
                 CustomTabBar(selectedTab: $selectedTab)
             }
@@ -76,22 +77,22 @@ struct CustomTabBar: View {
         }
         .frame(maxWidth: .infinity)
         .frame(height: 70)
-            // 2) 배경 그대로 유지
-            .background(
-                LinearGradient(
-                    gradient: Gradient(colors: [
-                        Color("btn_dark").opacity(0.95),
-                        Color("btn_light").opacity(0.95)
-                    ]),
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
+        // 2) 배경 그대로 유지
+        .background(
+            LinearGradient(
+                gradient: Gradient(colors: [
+                    Color("btn_dark").opacity(0.95),
+                    Color("btn_light").opacity(0.95)
+                ]),
+                startPoint: .top,
+                endPoint: .bottom
             )
-            // 3) 둥근 모서리·그림자 제거 → 하단 공백 X
-            //    필요하면 그림자만 남겨도 OK
-            // .shadow(radius: 10)
-            // 4) Safe Area 무시 → 홈 인디케이터까지 덮음
-            .ignoresSafeArea(.all, edges: .bottom)
+        )
+        // 3) 둥근 모서리·그림자 제거 → 하단 공백 X
+        //    필요하면 그림자만 남겨도 OK
+        // .shadow(radius: 10)
+        // 4) Safe Area 무시 → 홈 인디케이터까지 덮음
+        .ignoresSafeArea(.all, edges: .bottom)
     }
 }
 

--- a/MentBox/MentBox/Views/Learner/LearnerProfileView.swift
+++ b/MentBox/MentBox/Views/Learner/LearnerProfileView.swift
@@ -13,6 +13,7 @@ struct LearnerProfileView: View {
     @State private var chatPairs: [(question: ChatBox, answer: ChatBox)] = []
     @State private var mentors: [Mentor] = []
     @State private var isLoading = true
+    @EnvironmentObject var navigationManager: NavigationManager
 
     var body: some View {
         ZStack {
@@ -147,11 +148,10 @@ struct LearnerProfileView: View {
                             }
                             .padding(.horizontal, 16)
 
-                            // 로그아웃
                             Button(action: {
                                 do {
                                     try Auth.auth().signOut()
-                                    showSignInView = true
+                                    navigationManager.setAuthRoot()
                                 } catch {
                                     alertMessage = "로그아웃에 실패했습니다."
                                     showAlert = true
@@ -186,9 +186,6 @@ struct LearnerProfileView: View {
             }
         } message: {
             Text("이 질문을 삭제하시겠습니까?")
-        }
-        .fullScreenCover(isPresented: $showSignInView) {
-            SignInView()
         }
         .onAppear {
             loadUserData()

--- a/MentBox/MentBox/Views/Mentor/MentorMainView.swift
+++ b/MentBox/MentBox/Views/Mentor/MentorMainView.swift
@@ -4,6 +4,7 @@ struct MentorMainView: View {
     @State private var selectedTab = 0
     @State private var mentors: [Mentor] = []
     @State private var isLoading = true
+    @EnvironmentObject var navigationManager: NavigationManager
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -30,7 +31,10 @@ struct MentorMainView: View {
             
             MentorTabBar(selectedTab: $selectedTab)
         }
-        .onAppear { loadData() }
+        .onAppear {
+            print("MENTORVBIEW 나타남")
+            loadData()
+        }
     }
     
     private func loadData() {

--- a/MentBox/MentBox/Views/Mentor/MentorProfileView.swift
+++ b/MentBox/MentBox/Views/Mentor/MentorProfileView.swift
@@ -7,6 +7,7 @@ struct MentorProfileView: View {
     @State private var showAlert = false
     @State private var alertMessage = ""
     @State private var showSignInView = false
+    @EnvironmentObject var navigationManager: NavigationManager
     
     var body: some View {
         ZStack {
@@ -67,7 +68,7 @@ struct MentorProfileView: View {
                         Button(action: {
                             do {
                                 try Auth.auth().signOut()
-                                showSignInView = true
+                                navigationManager.setAuthRoot()
                             } catch {
                                 alertMessage = "로그아웃에 실패했습니다."
                                 showAlert = true
@@ -93,9 +94,7 @@ struct MentorProfileView: View {
         } message: {
             Text(alertMessage)
         }
-        .fullScreenCover(isPresented: $showSignInView) {
-            SignInView()
-        }
+        
         .onAppear {
             loadUserData()
         }


### PR DESCRIPTION
관련 이슈
- Closes #3 

📌 주요 변경 사항
- 기존 fullscreenCover 화면 전환 로직 -> NavigationManager로 변경
- NavigationManager에서 AppRootView enum 단일 루트 상태로 통합 관리
- 유저 로그아웃 후 재로그인시 화면 전환이 안되던 버그 수정  
- MentBoxApp.swift에서 화면루트 분기 처리 구현


### 예상외의 이슈
NavigationManager통해서 로그인이 성공했음에도 화면 전환이 이루어지지 않는 버그가 지속적으로 발생
처음에는 화면 전환은 되는데도, SwiftUI가 내부적으로 변경을 감지못해서 리렌더링이 안이루어지는지 알았으나,  각 View에 UUID를 적용해서 rootContent에서 `.id(id: Hashable)`를 통해서  강제 리렌더링을 시도했으나 효과 제로... 😰

문제는 각 러너/멘토의 ProfileView에서 로그아웃 버튼이 `NavigationManager`를 사용하지 않고, fullScreenCover를 통해 새로운 SignInView()를 위에 덧씌우는 구조여서, 실제 뷰 계층은 변화가 없는채로 이미 있는 페이지에서 다시 그페이지로 이동하라하니 fullScreenCover로 덮여진 상태에선 알아볼 수 없었던 것입니다! 

`onAppear`로 화면전환이 될때마다 print()를 찍음으로써 화면전환이 안됨을 파악하고 ProfileView에서 fullScreenCover를 제거하고 `NavigationManger.setAuthRoot()` 로 쉽게 해결할 수 있었습니다. 
